### PR TITLE
feat: :rocket: Comunicación entre microservicios http

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import express from "express"
 
 import router from "./routes/users"
 
-import { log, config, errorHandler, extensions } from "@repo/lib"
+import { log, errorHandler, extensions, services } from "@repo/lib"
 
 export const createServer = (): express.Express => {
 	const app = express()
@@ -25,6 +25,6 @@ export const createServer = (): express.Express => {
 
 const server = createServer()
 
-server.listen(config.api_port, () => {
-	log(`api running on ${config.api_port}`)
+server.listen(9999, () => {
+	log(`api running on ${9999}`)
 })

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -16,7 +16,7 @@ router.get("/", async (req, res, next) => {
 		}
 
 		const users = await prisma.user.findMany()
-		const jsonResponse: JsonResponse = {
+		const jsonResponse: JsonResponse<typeof users> = {
 			message: "Users found",
 			type: "success",
 			values: users,

--- a/packages/lib/.prettierrc
+++ b/packages/lib/.prettierrc
@@ -2,7 +2,7 @@
 	"semi": false,
 	"tabWidth": 4,
 	"useTabs": true,
-	"printWidth": 150,
+	"printWidth": 100,
 	"proseWrap": "preserve",
 	"singleQuote": false,
 	"arrowParens": "always",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -17,10 +17,10 @@
 		"@types/dotenv": "^8.2.0",
 		"@types/express": "^4.17.21",
 		"@types/node": "^20.11.24",
+		"dotenv-cli": "^7.4.2",
 		"prisma": "^5.10.2",
 		"tsup": "^8.0.2",
-		"typescript": "^5.3.3",
-		"dotenv-cli": "^7.4.2"
+		"typescript": "^5.3.3"
 	},
 	"dependencies": {
 		"@prisma/client": "^5.10.2",

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -1,7 +1,33 @@
 import dotenv from "dotenv"
+import { ServiceName, ServiceInfo } from "./types"
 
 dotenv.config({ path: "../../.env" })
 
-export const config = {
-	api_port: process.env.PORT || 3000,
+const envPortAsInt = (envVar: string, defaultPort: number) => {
+	return parseInt(process.env[envVar] ?? defaultPort.toString())
 }
+
+export const services: Record<ServiceName, ServiceInfo> = {
+	AUTH: {
+		url: (process.env.AUTH_SERVICE_URL ?? "http://localhost") as string,
+		port: envPortAsInt("AUTH_SERVICE_PORT", 3000),
+	},
+	DASHBOARD: {
+		url: (process.env.DASHBOARD_SERVICE_URL ?? "http://localhost") as string,
+		port: envPortAsInt("DASHBOARD_SERVICE_PORT", 4000),
+	},
+	STORAGE: {
+		url: (process.env.STORAGE_SERVICE_URL ?? "http://localhost") as string,
+		port: envPortAsInt("STORAGE_SERVICE_PORT", 5000),
+	},
+	ADMIN_WEB: {
+		url: (process.env.ADMIN_WEB_SERVICE_URL ?? "http://localhost") as string,
+		port: envPortAsInt("ADMIN_WEB_SERVICE_PORT", 8000),
+	},
+	PRO_WEB: {
+		url: (process.env.PRO_WEB_SERVICE_URL ?? "http://localhost") as string,
+		port: envPortAsInt("PRO_WEB_SERVICE_PORT", 9000),
+	},
+}
+
+console.table(services)

--- a/packages/lib/src/errors.ts
+++ b/packages/lib/src/errors.ts
@@ -4,9 +4,9 @@ import { NextFunction, Request, Response } from "express"
 
 export class AppError extends Error {
 	public code: number
-	public data: Record<string, unknown> | unknown[] | undefined
+	public data: Record<string, unknown> | unknown[] | null
 
-	constructor(code: number, message: string, data?: Record<string, unknown>) {
+	constructor(code: number, message: string, data: Record<string, unknown> = {}) {
 		super(message)
 		this.code = code
 		this.data = data
@@ -26,10 +26,11 @@ export const errorHandler = (err: unknown, req: Request, res: Response, next: Ne
 		return res.status(500).json({ message: "Internal Server Error", type: "error" })
 	}
 
-	const jsonResponse: JsonResponse = {
+	const jsonResponse: JsonResponse<typeof err.data | null> = {
+		status: err.code,
 		message: err.message,
 		type: "error",
-		values: err.data !== undefined ? err.data : null,
+		values: err.data ?? null,
 	}
 
 	return res.status(err.code).json(jsonResponse)

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -28,6 +28,7 @@ export const extensions = (req: Request, res: Response, next: NextFunction) => {
 	next()
 }
 
-export { config } from "./config"
+export { services } from "./config"
+export { httpRequest } from "./request"
 export type { JsonResponse } from "./types"
 export { AppError, AuthError, errorHandler } from "./errors"

--- a/packages/lib/src/request.ts
+++ b/packages/lib/src/request.ts
@@ -1,0 +1,78 @@
+import { AppError } from "."
+import { services } from "./config"
+import { JsonResponse, ContentTypeVariant, ServiceName, AllowedHttpMethod } from "./types"
+
+/**
+ * httpRequest is a function that sends a request to a service
+ * @param service - the service to send the request to
+ * @param endpoint - the endpoint to send the request to
+ * @param method - the http method to use for the request
+ * @param body - the body of the request
+ * @param variant - the content type variant of the request
+ * @returns a JsonResponse object
+ *
+ * @throws {Error} - if the service is not found in the services object
+ * @throws {Error} - if the method is GET and the body is not undefined
+ * @throws {Error} - if the variant is MULTIPART and the body is not an instance of FormData
+ * @throws {Error} - if the response is not ok
+ * @throws {Error} - if an unknown error occurs
+ *
+ * @example
+ *
+ * const response = await httpRequest<User[]>("DASHBOARD", "/provide-users", "GET", "JSON")
+ *
+ * response.values.forEach((user) => {
+ * 	console.log(user)
+ * })
+ *
+ * return res.status(200).json(response)
+ */
+
+export const httpRequest = async <T>(
+	service: ServiceName,
+	endpoint: string,
+	method: AllowedHttpMethod,
+	variant: ContentTypeVariant,
+	body?: any,
+): Promise<JsonResponse<T>> => {
+	if (!services[service]) {
+		throw new Error(`Service ${service} not found in services`)
+	}
+
+	if (method === "GET" && body) {
+		throw new Error("GET requests cannot have a body")
+	}
+
+	if (variant === "MULTIPART" && !(body instanceof FormData)) {
+		throw new Error("Body must be of type FormData")
+	}
+
+	const url = `${services[service].url}${endpoint}`
+	const headers = new Headers()
+
+	if (variant === "JSON") {
+		headers.append("Content-Type", "application/json")
+	}
+
+	try {
+		const response = await fetch(url, {
+			method,
+			headers,
+			body: variant === "JSON" ? JSON.stringify(body) : body,
+		})
+
+		const result = (await response.json()) as JsonResponse<T>
+
+		if (!response.ok) {
+			throw new AppError(
+				result.status || 500,
+				result.message,
+				(result.values || {}) as Record<string, unknown>,
+			)
+		}
+
+		return result
+	} catch (error: unknown) {
+		throw error
+	}
+}

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -1,5 +1,15 @@
-export type JsonResponse = {
+export type ContentTypeVariant = "JSON" | "MULTIPART"
+export type AllowedHttpMethod = "POST" | "PUT" | "DELETE" | "GET" | "PATCH"
+export type ServiceName = "AUTH" | "DASHBOARD" | "STORAGE" | "ADMIN_WEB" | "PRO_WEB"
+
+export type ServiceInfo = {
+	url: string
+	port: number
+}
+
+export type JsonResponse<T> = {
+	status?: number
 	message: string
 	type: "success" | "error"
-	values?: Record<string, unknown> | unknown[] | null
+	values: T
 }


### PR DESCRIPTION
- Se ha terminado y testeado la función que permite comunicar microservicios en formato json y multipart completamente tipado

- Se creó un diccionario que integra las direcciones/url de los servicios y sus puetos de ejecución.